### PR TITLE
Implement edit and delete group + fix delete group (#111)

### DIFF
--- a/sources/api/DbContext.cs
+++ b/sources/api/DbContext.cs
@@ -55,7 +55,7 @@ namespace DotNetAPI
                 entity.HasOne<Group>()
                       .WithMany()
                       .HasForeignKey(p => p.GroupId)
-                      .OnDelete(DeleteBehavior.Restrict);
+                      .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<Expense>(entity =>
@@ -65,7 +65,7 @@ namespace DotNetAPI
                 entity.HasOne<Group>()
                       .WithMany()
                       .HasForeignKey(p => p.GroupId)
-                      .OnDelete(DeleteBehavior.Restrict);
+                      .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<Debt>(entity =>
@@ -75,7 +75,7 @@ namespace DotNetAPI
                 entity.HasOne<Group>()
                       .WithMany()
                       .HasForeignKey(d => d.GroupId)
-                      .OnDelete(DeleteBehavior.Restrict);
+                      .OnDelete(DeleteBehavior.Cascade);
 
                 entity.HasOne<Expense>()
                       .WithMany()
@@ -95,12 +95,12 @@ namespace DotNetAPI
                 entity.HasOne<Group>(p => p.Group)
                       .WithMany()
                       .HasForeignKey(p => p.GroupId)
-                      .OnDelete(DeleteBehavior.Restrict);
+                      .OnDelete(DeleteBehavior.Cascade);
                 
-                entity.HasOne< DebtAdjustment>(p => p.DebtAdjustment)
+                entity.HasOne<DebtAdjustment>(p => p.DebtAdjustment)
                       .WithMany()
                       .HasForeignKey(p => p.DebtAdjustmentId)
-                      .OnDelete(DeleteBehavior.Restrict);
+                      .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<DebtAdjustment>(entity =>
@@ -120,7 +120,7 @@ namespace DotNetAPI
                 entity.HasOne<Group>(da => da.Group)
                      .WithMany()
                      .HasForeignKey(p => p.GroupId)
-                     .OnDelete(DeleteBehavior.Restrict);
+                     .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<UserInvolvedExpense>()

--- a/sources/api/Migrations/20240518182120_makeMigration.Designer.cs
+++ b/sources/api/Migrations/20240518182120_makeMigration.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DotNetAPI.Migrations
 {
     [DbContext(typeof(UserDbContext))]
-    [Migration("20240518032159_makeMigration")]
+    [Migration("20240518182120_makeMigration")]
     partial class makeMigration
     {
         /// <inheritdoc />
@@ -332,7 +332,7 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Group.Group", null)
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
@@ -347,7 +347,7 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Group.Group", null)
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.User.User", "UserInCredit")
@@ -372,7 +372,7 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Group.Group", "Group")
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.User.User", "UserInCredit")
@@ -424,7 +424,7 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Group.Group", null)
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.User.User", "User")
@@ -443,13 +443,13 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Debt.DebtAdjustment", "DebtAdjustment")
                         .WithMany()
                         .HasForeignKey("DebtAdjustmentId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.Group.Group", "Group")
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.User.User", "User")

--- a/sources/api/Migrations/20240518182120_makeMigration.cs
+++ b/sources/api/Migrations/20240518182120_makeMigration.cs
@@ -74,7 +74,7 @@ namespace DotNetAPI.Migrations
                         column: x => x.GroupId,
                         principalTable: "Group",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
@@ -97,7 +97,7 @@ namespace DotNetAPI.Migrations
                         column: x => x.GroupId,
                         principalTable: "Group",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_DebtAdjustments_User_UserInCreditId",
                         column: x => x.UserInCreditId,
@@ -166,7 +166,7 @@ namespace DotNetAPI.Migrations
                         column: x => x.GroupId,
                         principalTable: "Group",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_Expense_User_UserId",
                         column: x => x.UserId,
@@ -195,13 +195,13 @@ namespace DotNetAPI.Migrations
                         column: x => x.DebtAdjustmentId,
                         principalTable: "DebtAdjustments",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_Payment_Group_GroupId",
                         column: x => x.GroupId,
                         principalTable: "Group",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_Payment_User_UserId",
                         column: x => x.UserId,
@@ -237,7 +237,7 @@ namespace DotNetAPI.Migrations
                         column: x => x.GroupId,
                         principalTable: "Group",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_Debt_User_UserInCreditId",
                         column: x => x.UserInCreditId,

--- a/sources/api/Migrations/UserDbContextModelSnapshot.cs
+++ b/sources/api/Migrations/UserDbContextModelSnapshot.cs
@@ -329,7 +329,7 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Group.Group", null)
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
@@ -344,7 +344,7 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Group.Group", null)
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.User.User", "UserInCredit")
@@ -369,7 +369,7 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Group.Group", "Group")
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.User.User", "UserInCredit")
@@ -421,7 +421,7 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Group.Group", null)
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.User.User", "User")
@@ -440,13 +440,13 @@ namespace DotNetAPI.Migrations
                     b.HasOne("DotNetAPI.Models.Debt.DebtAdjustment", "DebtAdjustment")
                         .WithMany()
                         .HasForeignKey("DebtAdjustmentId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.Group.Group", "Group")
                         .WithMany()
                         .HasForeignKey("GroupId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("DotNetAPI.Models.User.User", "User")

--- a/sources/api/Startup.cs
+++ b/sources/api/Startup.cs
@@ -122,7 +122,7 @@ services.AddCors(options =>
     {
         // Migration done here
         app.UseDeveloperExceptionPage();
-        //dbContext.Database.Migrate();
+        dbContext.Database.Migrate();
         
         app.UseCors("AllowMyOrigin");
         app.UseRouting();

--- a/sources/mobile/app/src/main/java/com/console/ratcord/MainActivity.kt
+++ b/sources/mobile/app/src/main/java/com/console/ratcord/MainActivity.kt
@@ -16,6 +16,7 @@ sealed class Screen(val route: String) {
     object GroupDetails : Screen("group_details/{groupId}")
     object AddUserInGroup : Screen("addUserInGroup/{groupId}")
     object Groups : Screen("Groups")
+    object EditGroup : Screen("EditGroup/{groupId}")
     object EditUser : Screen("EditUser/{userId}")
     object EnsureConnexion : Screen("EnsureConnexion")
     object GroupsInvitation : Screen("GroupsInvitation")

--- a/sources/mobile/app/src/main/java/com/console/ratcord/api/GroupService.kt
+++ b/sources/mobile/app/src/main/java/com/console/ratcord/api/GroupService.kt
@@ -1,12 +1,18 @@
 package com.console.ratcord.api
 
 import android.content.Context
+import android.net.Uri
 import com.console.ratcord.domain.entity.exception.AuthorizationException
 import com.console.ratcord.domain.entity.group.GroupMinimal
 import com.console.ratcord.domain.entity.group.GroupMinimalWithId
+import com.console.ratcord.domain.entity.user.UserMinimal
 import io.ktor.client.HttpClient
+import io.ktor.client.request.delete
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
+import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
@@ -16,37 +22,11 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class GroupService() {
     private val client: HttpClient = Utils.getHttpClient()
-    suspend fun getGroups(context: Context): List<GroupMinimalWithId>? {
-        val response: HttpResponse = try {
-            client.get("http://10.0.2.2:5000/group") {
-                headers {
-                    append("Authorization", "Bearer ${Utils.getItem(context = context, fileKey = LocalStorage.PREFERENCES_FILE_KEY, key = LocalStorage.TOKEN_KEY)}")
-                }
-            }
-        } catch (e: Exception) {
-            println("Network error occurred: ${e.localizedMessage}")
-            return null
-        }
-
-        when (response.status) {
-            HttpStatusCode.Unauthorized -> {
-                throw AuthorizationException("Unauthorized access to user data.")
-            }
-
-            HttpStatusCode.OK -> {
-                val body: String = response.bodyAsText()
-                return Json.decodeFromString<List<GroupMinimalWithId>>(body)
-            }
-
-            else -> {
-                println("Received unexpected status: ${response.status}")
-                return null
-            }
-        }
-    }
 
     suspend fun getGroupById(context: Context, id: Int): GroupMinimalWithId? {
         val response: HttpResponse = try {
@@ -95,6 +75,60 @@ class GroupService() {
             return true
         } else {
             return false
+        }
+    }
+
+    suspend fun updateGroup(context: Context, groupMinimal: GroupMinimal, groupId: Int): Boolean {
+        val response: HttpResponse = try {
+            client.patch("http://10.0.2.2:5000/group/$groupId") {
+                headers {
+                    append("Authorization", "Bearer ${Utils.getItem(context = context, fileKey = LocalStorage.PREFERENCES_FILE_KEY, key = LocalStorage.TOKEN_KEY)}")
+                    contentType(ContentType.Application.Json)
+                    setBody(groupMinimal)
+                }
+            }
+        } catch (e: Exception) {
+            println("Network error occurred: ${e.localizedMessage}")
+            return false
+        }
+
+        when (response.status) {
+            HttpStatusCode.Unauthorized -> {
+                throw AuthorizationException("Unauthorized access to data.")
+            }
+            HttpStatusCode.NoContent -> {
+                return true
+            }
+            else -> {
+                println("Received unexpected status: ${response.status}")
+                return false
+            }
+        }
+    }
+
+    suspend fun deleteGroup(context: Context, groupId: Int): Boolean {
+        val response: HttpResponse = try {
+            client.delete("http://10.0.2.2:5000/group/$groupId") {
+                headers {
+                    append("Authorization", "Bearer ${Utils.getItem(context = context, fileKey = LocalStorage.PREFERENCES_FILE_KEY, key = LocalStorage.TOKEN_KEY)}")
+                }
+            }
+        } catch (e: Exception) {
+            println("Network error occurred: ${e.localizedMessage}")
+            return false
+        }
+
+        when (response.status) {
+            HttpStatusCode.Unauthorized -> {
+                throw AuthorizationException("Unauthorized access to data.")
+            }
+            HttpStatusCode.NoContent -> {
+                return true
+            }
+            else -> {
+                println("Received unexpected status: ${response.status}")
+                return false
+            }
         }
     }
 }

--- a/sources/mobile/app/src/main/java/com/console/ratcord/ui/theme/component/EditGroup.kt
+++ b/sources/mobile/app/src/main/java/com/console/ratcord/ui/theme/component/EditGroup.kt
@@ -1,0 +1,99 @@
+import android.content.Context
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.navigation.NavController
+import com.console.ratcord.Screen
+import com.console.ratcord.api.GroupService
+import com.console.ratcord.domain.entity.group.GroupMinimal
+
+@Composable
+fun EditGroup(groupService: GroupService, applicationContext: Context, navController: NavController, groupId: Int?) {
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    if (groupId != null) {
+        var groupName by remember { mutableStateOf("") }
+        var groupDescription by remember { mutableStateOf("") }
+
+        val coroutineScope = rememberCoroutineScope()
+
+        Column(modifier = Modifier.padding(PaddingValues(16.dp))) {
+            errorMessage?.let { message ->
+                AlertBaner(message = message, onAnimationEnd = { errorMessage = null })
+            }
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    imageVector =  Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Go back",
+                )
+            }
+
+            IconButton(onClick = {
+                coroutineScope.launch {
+                    groupService.deleteGroup(context = applicationContext, groupId = groupId)
+                }
+                navController.navigate(Screen.Groups.route)
+            }) {
+                Icon(
+                    imageVector = Icons.Filled.Delete,
+                    contentDescription = "Delete Group",
+                )
+            }
+
+            OutlinedTextField(
+                value = groupName,
+                onValueChange = { groupName = it },
+                label = { Text("Name") },
+                modifier = Modifier.padding(top = 8.dp)
+            )
+            OutlinedTextField(
+                value = groupDescription,
+                onValueChange = { groupDescription = it },
+                label = { Text("Description") },
+                modifier = Modifier.padding(top = 8.dp)
+            )
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        val groupMinimal = GroupMinimal(
+                            groupName = groupName,
+                            groupDesc  = groupDescription,
+                        )
+                        if (groupService.updateGroup(
+                            context = applicationContext,
+                            groupId = groupId,
+                            groupMinimal = groupMinimal))
+                        {
+                            navController.navigate(Screen.Groups.route)
+
+                        } else {
+                            errorMessage = "Something went wrong, please try again"
+                        }
+
+                    }
+                },
+                modifier = Modifier.padding(top = 16.dp)
+            ) {
+                Text("Update")
+            }
+        }
+    }
+}

--- a/sources/mobile/app/src/main/java/com/console/ratcord/ui/theme/component/Navigation.kt
+++ b/sources/mobile/app/src/main/java/com/console/ratcord/ui/theme/component/Navigation.kt
@@ -167,6 +167,20 @@ class Navigation() {
                         navController = navController
                     )
                 }
+                composable(
+                    "${Screen.EditGroup}/{groupId}",
+                    arguments = listOf(navArgument("groupId") { type = NavType.IntType })
+                ) { navBackStackEntry ->
+                    val groupId = navBackStackEntry.arguments?.getInt("groupId")
+                    if (groupId != null) {
+                        EditGroup(
+                            groupId = groupId,
+                            applicationContext = applicationContext,
+                            navController = navController,
+                            groupService = groupService
+                        )
+                    }
+                }
                 composable(Screen.PrivateChat.route) {
                     val loggedInUser: String? = Utils.getItem(
                         context = applicationContext,

--- a/sources/mobile/app/src/main/java/com/console/ratcord/ui/theme/screen/GroupDetails.kt
+++ b/sources/mobile/app/src/main/java/com/console/ratcord/ui/theme/screen/GroupDetails.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -23,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.console.ratcord.ExpenseTab
 import com.console.ratcord.Screen
 import com.console.ratcord.api.ExpenseService
 import com.console.ratcord.api.GroupService
@@ -75,6 +77,11 @@ fun GroupDetails(groupService: GroupService, userInGroupService: UserInGroupServ
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "Go back")
+                }
+                IconButton(onClick = { navController.navigate("${Screen.EditGroup}/${groupId}") }) {
+                    Icon(
+                        imageVector = Icons.Filled.Edit,
+                        contentDescription = "Edit group")
                 }
                 Text(
                     "Name: ${groupDetails!!.groupName}",

--- a/sources/mobile/app/src/main/java/com/console/ratcord/ui/theme/screen/ProfileDetails.kt
+++ b/sources/mobile/app/src/main/java/com/console/ratcord/ui/theme/screen/ProfileDetails.kt
@@ -50,6 +50,8 @@ fun ProfileDetail(userService: UserService, applicationContext: Context, navCont
                         userDetails = userService.getUserById(applicationContext, userId)
                     } catch (e: Exception) {
                         println("Failed to retrieve user: ${e.message}")
+                        Utils.storeItem(context = applicationContext, value = null, fileKey = LocalStorage.PREFERENCES_FILE_KEY, key = LocalStorage.TOKEN_KEY)
+                        Utils.storeItem(context = applicationContext, value = null, fileKey = LocalStorage.PREFERENCES_FILE_KEY, key = LocalStorage.USER)
                     } finally {
                         isLoading = false
                     }


### PR DESCRIPTION
Implement edit and delete group within mobile app. 
Fix group delete. Since it is attached to several other entities, I had to make them delete OnCascade (Expense, Debt*, Categories)